### PR TITLE
Adopt Pydantic models with offline fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/ragx/README.md
+++ b/ragx/README.md
@@ -1,0 +1,5 @@
+# RAGX
+
+RAGX ist ein Forschungs- und Entwicklungsprojekt für ein Retrieval-Augmented-Generation-System
+mit Reduce-&-Delegate-Agenten. Diese Codebasis enthält eine minimal funktionsfähige
+Implementierung inklusive Unit-Tests, Konfiguration und Public-APIs.

--- a/ragx/examples/evaluate.py
+++ b/ragx/examples/evaluate.py
@@ -1,0 +1,14 @@
+"""Small evaluation script for RAGX."""
+
+from ragx.api import public_api
+
+if __name__ == "__main__":
+    documents = [
+        "Solar energy adoption accelerated in Europe between 2019 and 2024 due to subsidies.",
+        "Wind power complements solar by providing generation during night hours.",
+        "Grid storage projects balance renewable variability and ensure reliability.",
+    ]
+    public_api._reset_state_for_tests()
+    public_api.index_documents(documents)
+    result = public_api.answer("How do solar and wind complement each other?")
+    print(result.model_dump())

--- a/ragx/pyproject.toml
+++ b/ragx/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ragx"
+version = "0.1.0"
+description = "R&D RAG system with specialist agents"
+requires-python = ">=3.11"
+authors = [
+    {name = "RAGX Team", email = "team@example.com"}
+]
+readme = "README.md"
+dependencies = [
+    "pydantic>=2.4",
+    "numpy>=1.26",
+    "networkx>=3.1",
+    "pyyaml>=6.0",
+    "tiktoken>=0.7.0",
+    "rich>=13.0"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "black>=24.0",
+    "ruff>=0.4"
+]
+
+[tool.black]
+line-length = 100
+target-version = ['py311']
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-q"
+pythonpath = ["ragx"]

--- a/ragx/ragx/__init__.py
+++ b/ragx/ragx/__init__.py
@@ -1,0 +1,10 @@
+"""RAGX package exports public API shortcuts."""
+
+from .models import Chunk, ContextBundle, QueryResult, RetrievedChunk
+
+__all__ = [
+    "Chunk",
+    "ContextBundle",
+    "QueryResult",
+    "RetrievedChunk",
+]

--- a/ragx/ragx/_compat.py
+++ b/ragx/ragx/_compat.py
@@ -1,0 +1,36 @@
+"""Compatibility helpers providing light-weight Pydantic fallbacks."""
+
+from __future__ import annotations
+
+from dataclasses import MISSING, asdict, dataclass, field as dataclass_field
+from typing import Any, Dict, Optional
+
+
+class BaseModel:
+    """Minimal stand-in replicating key Pydantic BaseModel APIs."""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # pragma: no cover - simple shim
+        dataclass(cls)
+        super().__init_subclass__(**kwargs)
+
+    def model_dump(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def model_copy(self, update: Optional[Dict[str, Any]] = None):
+        data = self.model_dump()
+        if update:
+            data.update(update)
+        return type(self)(**data)
+
+
+def Field(*, default: Any = MISSING, default_factory: Any = MISSING):  # pragma: no cover - shim
+    if default is not MISSING and default_factory is not MISSING:
+        raise ValueError("default and default_factory are mutually exclusive")
+    if default_factory is not MISSING:
+        return dataclass_field(default_factory=default_factory)
+    if default is not MISSING:
+        return dataclass_field(default=default)
+    return dataclass_field()
+
+
+__all__ = ["BaseModel", "Field"]

--- a/ragx/ragx/api/__init__.py
+++ b/ragx/ragx/api/__init__.py
@@ -1,0 +1,1 @@
+"""Public API package for RAGX."""

--- a/ragx/ragx/api/public_api.py
+++ b/ragx/ragx/api/public_api.py
@@ -1,0 +1,200 @@
+"""Public API for RAGX."""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+from ..config import ConfigManager
+from ..control.budget import ContextBudgeter
+from ..control.crag import CRAGEvaluator
+from ..control.planner import Planner
+from ..control.selfrag import SelfRAGRewriter
+from ..generation.critic import Critic
+from ..generation.generator import Generator
+from ..index.dynamic import DynamicIndexer
+from ..models import QueryResult, RetrievedChunk
+from ..packing import Repacker
+from ..retrievers.graphrag_adapter import GraphRAGAdapter
+from ..retrievers.hybrid import HybridRetriever
+from ..rerank.monot5 import MonoT5Reranker
+from ..rerank.tildev2 import TILDEV2Reranker
+from ..summarize.longllmlingua import LongLLMLinguaSummarizer
+from ..summarize.recomp import RecompSummarizer
+from ..embeddings import RandomEmbeddingBackend
+from ..chunking import DocumentChunker
+from ..retrievers.tensor_iface import TensorRetrieverInterface
+
+
+@dataclass
+class _AppState:
+    config: ConfigManager
+    indexer: DynamicIndexer
+    retriever: HybridRetriever
+    tensor_iface: TensorRetrieverInterface
+    graph: GraphRAGAdapter
+    planner: Planner
+    repacker: Repacker
+    generator: Generator
+    critic: Critic
+    crag: CRAGEvaluator
+    selfrag: SelfRAGRewriter
+
+
+_graph_adapter = GraphRAGAdapter()
+_indexer = DynamicIndexer(
+    chunker=DocumentChunker(), embedding_backend=RandomEmbeddingBackend(), graph_adapter=_graph_adapter
+)
+
+_state = _AppState(
+    config=ConfigManager(),
+    graph=_graph_adapter,
+    indexer=_indexer,
+    retriever=HybridRetriever(_indexer),
+    tensor_iface=TensorRetrieverInterface(),
+    planner=Planner(),
+    repacker=Repacker(),
+    generator=Generator(),
+    critic=Critic(),
+    crag=CRAGEvaluator(),
+    selfrag=SelfRAGRewriter(),
+)
+
+_SUMMARIZERS = {
+    "recomp": RecompSummarizer(),
+    "longllmlingua": LongLLMLinguaSummarizer(),
+}
+_RERANKERS = {
+    "monoT5": MonoT5Reranker(),
+    "tildev2": TILDEV2Reranker(),
+}
+
+
+def index_documents(documents: List[str]) -> int:
+    """Chunk -> Embed -> Index (Hybrid + Graph + TensorIF)."""
+
+    count = _state.indexer.index_documents(documents)
+    _refresh_tensor_index()
+    return count
+
+
+def upsert_documents(docs: List[str]) -> int:
+    """Inkrementell upserten (Redaction+Index+KG+TensorIF)."""
+
+    count = _state.indexer.upsert_documents(docs)
+    _refresh_tensor_index()
+    return count
+
+
+def answer(query: str, profile: str = "balanced_efficiency") -> QueryResult:
+    plan = ["retrieve", "rerank", "pack", "summarize", "budget", "generate", "critic"]
+    return _run_pipeline(query, profile, plan)
+
+
+def answer_agentic(query: str, profile: str = "balanced_efficiency") -> QueryResult:
+    plan_steps = [step.name for step in _state.planner.plan(query)]
+    return _run_pipeline(query, profile, plan_steps)
+
+
+def set_alpha(value: float) -> None:
+    _state.retriever.set_alpha(value)
+
+
+def _run_pipeline(query: str, profile: str, plan: List[str]) -> QueryResult:
+    config = _state.config.load(profile=profile)
+    retrieval_top_k = config["retrieval"].get("top_k", 10)
+    rerank_top_k = config["rerank"].get("top_k", 5)
+    alpha = config["retrieval"].get("alpha", 0.3)
+    _state.retriever.set_alpha(alpha)
+
+    retrieved: List[RetrievedChunk] = []
+    reranked: List[RetrievedChunk] = []
+    context = ""
+    response = ""
+    rewrites: List[str] = []
+    current_query = query
+    primary = _SUMMARIZERS[config["summarization"].get("primary", "recomp")]
+    fallback = _SUMMARIZERS[config["summarization"].get("fallback", "longllmlingua")]
+    budgeter = ContextBudgeter(config["budget"].get("max_context_tokens", 2500), primary, fallback)
+    critic_status = "PENDING"
+    crag_score = 0.0
+    budget_strategy = "none"
+    critic_retries = 0
+
+    for step in plan:
+        if step == "retrieve":
+            retrieved = _state.retriever.retrieve(current_query, top_k=retrieval_top_k)
+            evaluation = _state.crag.evaluate(retrieved)
+            crag_score = evaluation.score
+            if evaluation.action == "retry":
+                rewrite_result = _state.selfrag.rewrite_loop(current_query, retrieved)
+                rewrites = rewrite_result.rewrites
+                current_query = rewrite_result.final_query
+                if rewrites:
+                    retrieved = _state.retriever.retrieve(current_query, top_k=retrieval_top_k)
+                    crag_score = _state.crag.evaluate(retrieved).score
+        elif step == "graph_retrieve":
+            additional = _state.graph.retrieve_via_graph(current_query, _state.indexer.index.chunks)
+            known_ids = {chunk.chunk_id for chunk in retrieved}
+            for chunk in additional:
+                if chunk.chunk_id not in known_ids:
+                    retrieved.append(chunk)
+                    known_ids.add(chunk.chunk_id)
+        elif step == "rerank":
+            reranker_name = config["rerank"].get("method", "monoT5")
+            reranker = _RERANKERS.get(reranker_name, MonoT5Reranker())
+            reranked = reranker.rerank(retrieved, current_query, top_k=rerank_top_k)
+        elif step == "pack":
+            context = _state.repacker.pack(reranked, mode=config.get("packing", "reverse"))
+        elif step == "summarize":
+            # Summaries are produced during budget enforcement
+            pass
+        elif step == "budget":
+            budget_result = budgeter.enforce(context, reranked)
+            context = budget_result.context
+            budget_strategy = budget_result.strategy
+        elif step == "generate":
+            response = _state.generator.generate(query, context, reranked)
+        elif step == "critic":
+            critic_status = _state.critic.evaluate(response, context, reranked)
+            if critic_status == "LOW_CONFIDENCE":
+                fallback_context = fallback.summarize(reranked, target_tokens=config["budget"].get("max_context_tokens", 2500))
+                context = budgeter._truncate(fallback_context)
+                response = _state.generator.generate(query, context, reranked)
+                critic_status = _state.critic.evaluate(response, context, reranked)
+                critic_retries += 1
+
+    query_type = _state.planner.classify(query)
+    return QueryResult(
+        query=query,
+        needs_retrieval=True,
+        query_type=query_type,
+        retrieved=reranked,
+        context=context,
+        response=response,
+        meta={
+            "profile": profile,
+            "rewrites": str(len(rewrites)),
+            "critic_status": critic_status,
+            "alpha": f"{alpha:.2f}",
+            "crag_score": f"{crag_score:.3f}",
+            "budget_strategy": budget_strategy,
+            "critic_retries": str(critic_retries),
+        },
+    )
+
+
+def _refresh_tensor_index() -> None:
+    _state.tensor_iface.index(_state.indexer.index.chunks.values())
+
+
+def _reset_state_for_tests() -> None:  # pragma: no cover - used in unit tests
+    _state.graph = GraphRAGAdapter()
+    _state.indexer.graph_adapter = _state.graph
+    _state.indexer.index.clear()
+    _state.indexer._doc_counter = itertools.count()
+    _state.tensor_iface = TensorRetrieverInterface()
+
+
+__all__ = ["index_documents", "answer", "answer_agentic", "upsert_documents", "set_alpha"]

--- a/ragx/ragx/chunking.py
+++ b/ragx/ragx/chunking.py
@@ -1,0 +1,62 @@
+"""Utilities to split documents into chunks."""
+
+from __future__ import annotations
+
+import itertools
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .models import Chunk
+
+
+def _split_sentences(text: str) -> List[str]:
+    cleaned = text.replace("\n", " ").strip()
+    if not cleaned:
+        return []
+    sentences = re.split(r"(?<=[.!?])\s+", cleaned)
+    return [sentence.strip() for sentence in sentences if sentence.strip()]
+
+
+@dataclass
+class ChunkerConfig:
+    window_size: int = 3
+    stride: int = 2
+    small_to_big: bool = True
+
+
+class DocumentChunker:
+    """Sentence-based chunker supporting sliding windows and small-to-big merging."""
+
+    def __init__(self, config: ChunkerConfig | None = None) -> None:
+        self.config = config or ChunkerConfig()
+        self._counter = itertools.count()
+
+    def chunk(self, doc_id: str, text: str) -> List[Chunk]:
+        sentences = _split_sentences(text)
+        if not sentences:
+            return []
+
+        if self.config.small_to_big and len(sentences) <= self.config.window_size:
+            chunk_id = f"{doc_id}::chunk::{next(self._counter)}"
+            return [Chunk(chunk_id=chunk_id, doc_id=doc_id, text=" ".join(sentences))]
+
+        window = max(1, self.config.window_size)
+        stride = max(1, self.config.stride)
+        chunks: List[Chunk] = []
+        for start in range(0, len(sentences), stride):
+            window_sentences = sentences[start : start + window]
+            if not window_sentences:
+                break
+            chunk_id = f"{doc_id}::chunk::{next(self._counter)}"
+            chunk_text = " ".join(window_sentences)
+            chunks.append(Chunk(chunk_id=chunk_id, doc_id=doc_id, text=chunk_text))
+            if start + window >= len(sentences):
+                break
+        return chunks
+
+    def chunk_many(self, documents: Iterable[tuple[str, str]]) -> List[Chunk]:
+        return [chunk for doc_id, text in documents for chunk in self.chunk(doc_id, text)]
+
+
+__all__ = ["DocumentChunker", "ChunkerConfig"]

--- a/ragx/ragx/config.py
+++ b/ragx/ragx/config.py
@@ -1,0 +1,130 @@
+"""Configuration management for RAGX."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - fallback when PyYAML missing
+    yaml = None
+
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "profile": "balanced_efficiency",
+    "retrieval": {
+        "method": "hybrid",
+        "alpha": 0.30,
+        "top_k": 10,
+    },
+    "rerank": {
+        "method": "monoT5",
+        "top_k": 5,
+    },
+    "packing": "reverse",
+    "summarization": {
+        "primary": "recomp",
+        "fallback": "longllmlingua",
+    },
+    "budget": {
+        "max_context_tokens": 2500,
+    },
+    "crag": {
+        "min_score": 0.55,
+    },
+    "selfrag": {
+        "max_loops": 2,
+    },
+    "tensor": {
+        "enabled": False,
+    },
+    "mcp": {
+        "servers": [],
+    },
+}
+
+
+PROFILE_OVERRIDES: Dict[str, Dict[str, Any]] = {
+    "best_performance": {
+        "retrieval": {"alpha": 0.35, "top_k": 12},
+        "rerank": {"top_k": 8},
+        "budget": {"max_context_tokens": 3200},
+    },
+    "balanced_efficiency": {},
+    "custom": {},
+}
+
+
+@dataclass
+class ConfigManager:
+    """Utility that merges YAML, profile defaults and environment overrides."""
+
+    config_path: Optional[Path] = None
+    base_config: Dict[str, Any] = field(default_factory=lambda: DEFAULT_CONFIG.copy())
+
+    def load(self, profile: Optional[str] = None, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        profile = profile or self.base_config.get("profile", "balanced_efficiency")
+        merged: Dict[str, Any] = {}
+        _merge_dicts(merged, self.base_config)
+
+        if self.config_path and self.config_path.exists() and yaml:
+            with self.config_path.open("r", encoding="utf-8") as handle:
+                yaml_config = yaml.safe_load(handle) or {}
+            _merge_dicts(merged, yaml_config)
+
+        profile_overrides = PROFILE_OVERRIDES.get(profile, {})
+        _merge_dicts(merged, profile_overrides)
+
+        if overrides:
+            _merge_dicts(merged, overrides)
+
+        env_overrides = _env_overrides()
+        if env_overrides:
+            _merge_dicts(merged, env_overrides)
+
+        merged["profile"] = profile
+        return merged
+
+
+def _merge_dicts(base: Dict[str, Any], updates: Dict[str, Any]) -> None:
+    for key, value in updates.items():
+        if isinstance(value, dict):
+            node = base.setdefault(key, {})
+            if isinstance(node, dict):
+                _merge_dicts(node, value)
+            else:
+                base[key] = value
+        else:
+            base[key] = value
+
+
+def _env_overrides() -> Dict[str, Any]:
+    overrides: Dict[str, Any] = {}
+    alpha = os.getenv("RAGX_ALPHA")
+    if alpha is not None:
+        try:
+            overrides.setdefault("retrieval", {})["alpha"] = float(alpha)
+        except ValueError:
+            pass
+
+    top_k = os.getenv("RAGX_TOP_K")
+    if top_k is not None:
+        try:
+            overrides.setdefault("retrieval", {})["top_k"] = int(top_k)
+        except ValueError:
+            pass
+
+    budget = os.getenv("RAGX_MAX_CONTEXT")
+    if budget is not None:
+        try:
+            overrides.setdefault("budget", {})["max_context_tokens"] = int(budget)
+        except ValueError:
+            pass
+
+    return overrides
+
+
+__all__ = ["ConfigManager", "DEFAULT_CONFIG", "PROFILE_OVERRIDES"]

--- a/ragx/ragx/control/__init__.py
+++ b/ragx/ragx/control/__init__.py
@@ -1,0 +1,1 @@
+"""Control plane for RAGX agent orchestration."""

--- a/ragx/ragx/control/budget.py
+++ b/ragx/ragx/control/budget.py
@@ -1,0 +1,55 @@
+"""Token budget gate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from ..models import RetrievedChunk
+
+try:  # pragma: no cover - optional dependency
+    import tiktoken
+except Exception:  # pragma: no cover
+    tiktoken = None
+
+
+@dataclass
+class BudgetResult:
+    context: str
+    strategy: str
+
+
+class ContextBudgeter:
+    def __init__(self, max_tokens: int, primary, fallback) -> None:
+        self.max_tokens = max_tokens
+        self.primary = primary
+        self.fallback = fallback
+        self._tokenizer = tiktoken.get_encoding("cl100k_base") if tiktoken else None
+
+    def _count_tokens(self, text: str) -> int:
+        if not text:
+            return 0
+        if self._tokenizer is not None:
+            return len(self._tokenizer.encode(text))
+        return len(text.split())
+
+    def enforce(self, context: str, chunks: Iterable[RetrievedChunk]) -> BudgetResult:
+        tokens = self._count_tokens(context)
+        if tokens <= self.max_tokens:
+            return BudgetResult(context=context, strategy="none")
+        primary_summary = self.primary.summarize(chunks, target_tokens=self.max_tokens)
+        if self._count_tokens(primary_summary) <= self.max_tokens:
+            return BudgetResult(context=primary_summary, strategy="primary")
+        fallback_summary = self.fallback.summarize(chunks, target_tokens=self.max_tokens)
+        truncated = self._truncate(fallback_summary)
+        return BudgetResult(context=truncated, strategy="fallback")
+
+    def _truncate(self, text: str) -> str:
+        words = text.split()
+        if not words:
+            return text
+        budget_words = words[: self.max_tokens]
+        return " ".join(budget_words)
+
+
+__all__ = ["ContextBudgeter", "BudgetResult"]

--- a/ragx/ragx/control/crag.py
+++ b/ragx/ragx/control/crag.py
@@ -1,0 +1,38 @@
+"""CRAG evaluator heuristics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from ..models import RetrievedChunk
+
+
+@dataclass
+class CRAGEvaluation:
+    score: float
+    coverage: float
+    diversity: float
+    contradiction: float
+    action: str
+
+
+class CRAGEvaluator:
+    def __init__(self, min_score: float = 0.55) -> None:
+        self.min_score = min_score
+
+    def evaluate(self, chunks: Iterable[RetrievedChunk]) -> CRAGEvaluation:
+        chunk_list = list(chunks)
+        if not chunk_list:
+            return CRAGEvaluation(0.0, 0.0, 0.0, 0.0, "retry")
+
+        coverage = sum(chunk.retrieval_score for chunk in chunk_list) / len(chunk_list)
+        unique_docs = {chunk.doc_id for chunk in chunk_list}
+        diversity = len(unique_docs) / len(chunk_list)
+        contradiction = 0.0  # Placeholder for NLI hook
+        score = (coverage + diversity - contradiction) / 2
+        action = "retry" if score < self.min_score else "ok"
+        return CRAGEvaluation(score, coverage, diversity, contradiction, action)
+
+
+__all__ = ["CRAGEvaluator", "CRAGEvaluation"]

--- a/ragx/ragx/control/planner.py
+++ b/ragx/ragx/control/planner.py
@@ -1,0 +1,46 @@
+"""Planner orchestrating specialist agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class PlanStep:
+    name: str
+    params: Dict[str, object]
+
+
+class Planner:
+    COMPARE_KEYWORDS = {"compare", "versus", "vs", "evolution", "trend", "global"}
+
+    def __init__(self) -> None:
+        pass
+
+    def classify(self, query: str) -> str:
+        lowered = query.lower()
+        if any(keyword in lowered for keyword in {"how", "why", "explain"}):
+            return "analysis"
+        if any(keyword in lowered for keyword in self.COMPARE_KEYWORDS):
+            return "compare"
+        return "lookup"
+
+    def plan(self, query: str) -> List[PlanStep]:
+        query_type = self.classify(query)
+        steps = [PlanStep("retrieve", {}), PlanStep("rerank", {})]
+        if query_type == "compare":
+            steps.append(PlanStep("graph_retrieve", {}))
+        steps.extend(
+            [
+                PlanStep("pack", {}),
+                PlanStep("summarize", {}),
+                PlanStep("budget", {}),
+                PlanStep("generate", {}),
+                PlanStep("critic", {}),
+            ]
+        )
+        return steps
+
+
+__all__ = ["Planner", "PlanStep"]

--- a/ragx/ragx/control/selfrag.py
+++ b/ragx/ragx/control/selfrag.py
@@ -1,0 +1,52 @@
+"""Self-RAG style query rewriting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from ..index.dynamic import _tokenize
+from ..models import RetrievedChunk
+
+
+@dataclass
+class RewriteResult:
+    final_query: str
+    rewrites: List[str]
+
+
+class SelfRAGRewriter:
+    def __init__(self, max_loops: int = 2) -> None:
+        self.max_loops = max_loops
+
+    def propose(self, query: str, chunks: Iterable[RetrievedChunk]) -> str:
+        query_tokens = set(_tokenize(query))
+        additions: List[str] = []
+        for chunk in chunks:
+            for token in _tokenize(chunk.text):
+                if len(token) <= 4:
+                    continue
+                if token in query_tokens or token in additions:
+                    continue
+                additions.append(token)
+                if len(additions) >= 3:
+                    break
+            if len(additions) >= 3:
+                break
+        if not additions:
+            return query
+        return f"{query} {' '.join(additions[:2])}".strip()
+
+    def rewrite_loop(self, query: str, chunks: Iterable[RetrievedChunk]) -> RewriteResult:
+        rewrites: List[str] = []
+        current_query = query
+        for _ in range(self.max_loops):
+            new_query = self.propose(current_query, chunks)
+            if new_query == current_query:
+                break
+            rewrites.append(new_query)
+            current_query = new_query
+        return RewriteResult(final_query=current_query, rewrites=rewrites)
+
+
+__all__ = ["SelfRAGRewriter", "RewriteResult"]

--- a/ragx/ragx/embeddings.py
+++ b/ragx/ragx/embeddings.py
@@ -1,0 +1,56 @@
+"""Embedding backends using deterministic pseudo-random vectors."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Iterable, List
+
+
+class EmbeddingBackend:
+    """Abstract embedding backend."""
+
+    dimension: int = 128
+
+    def embed_documents(self, texts: Iterable[str]) -> List[List[float]]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def embed_query(self, text: str) -> List[float]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class RandomEmbeddingBackend(EmbeddingBackend):
+    """Deterministic embedding backend relying on hashing."""
+
+    def __init__(self, dimension: int = 128, global_seed: int = 13) -> None:
+        self.dimension = dimension
+        self.global_seed = global_seed
+
+    def embed_documents(self, texts: Iterable[str]) -> List[List[float]]:
+        return [self._embed(text) for text in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return self._embed(text)
+
+    def _embed(self, text: str) -> List[float]:
+        values: List[float] = []
+        for index in range(self.dimension):
+            digest = hashlib.sha256(f"{self.global_seed}:{index}:{text}".encode("utf-8")).digest()
+            raw = int.from_bytes(digest[:4], "big", signed=False)
+            normalized = (raw % 2000) / 1000.0 - 1.0
+            values.append(normalized)
+        norm = math.sqrt(sum(value * value for value in values))
+        if norm == 0:
+            return values
+        return [value / norm for value in values]
+
+
+def cosine_similarity(query: List[float], matrix: List[List[float]]) -> List[float]:
+    scores: List[float] = []
+    for vector in matrix:
+        score = sum(q * v for q, v in zip(query, vector))
+        scores.append(score)
+    return scores
+
+
+__all__ = ["EmbeddingBackend", "RandomEmbeddingBackend", "cosine_similarity"]

--- a/ragx/ragx/generation/__init__.py
+++ b/ragx/ragx/generation/__init__.py
@@ -1,0 +1,1 @@
+"""Generation components for RAGX."""

--- a/ragx/ragx/generation/critic.py
+++ b/ragx/ragx/generation/critic.py
@@ -1,0 +1,33 @@
+"""Faithfulness critic heuristics."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from ..models import RetrievedChunk
+
+
+class Critic:
+    def evaluate(self, response: str, context: str, chunks: Iterable[RetrievedChunk]) -> str:
+        if not response:
+            return "LOW_CONFIDENCE"
+        try:
+            payload = json.loads(response)
+        except json.JSONDecodeError:
+            return "LOW_CONFIDENCE"
+
+        quotes = payload.get("quotes", [])
+        answer = payload.get("answer", "")
+        if not quotes:
+            return "LOW_CONFIDENCE"
+        context_lower = context.lower()
+        for quote in quotes:
+            if quote and quote.lower() in context_lower:
+                return "OK"
+        if answer and answer.lower() in context_lower:
+            return "OK"
+        return "LOW_CONFIDENCE"
+
+
+__all__ = ["Critic"]

--- a/ragx/ragx/generation/generator.py
+++ b/ragx/ragx/generation/generator.py
@@ -1,0 +1,33 @@
+"""Generator producing schema-aligned responses."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from ..models import RetrievedChunk
+
+
+class Generator:
+    def generate(self, query: str, context: str, chunks: Iterable[RetrievedChunk]) -> str:
+        chunk_list = list(chunks)
+        if not context.strip() or not chunk_list:
+            payload = {
+                "answer": "Keine passenden Informationen gefunden.",
+                "quotes": [],
+                "disclaimer": "LOW_CONFIDENCE",
+            }
+            return json.dumps(payload, ensure_ascii=False)
+
+        best_chunk = max(chunk_list, key=lambda c: c.rerank_score or c.retrieval_score)
+        first_sentence = best_chunk.text.split(". ")[0].strip()
+        payload = {
+            "answer": first_sentence,
+            "quotes": [first_sentence[:120]],
+        }
+        if len(chunk_list) > 1:
+            payload["quotes"].append(chunk_list[1].text.split(". ")[0].strip())
+        return json.dumps(payload, ensure_ascii=False)
+
+
+__all__ = ["Generator"]

--- a/ragx/ragx/index/__init__.py
+++ b/ragx/ragx/index/__init__.py
@@ -1,0 +1,1 @@
+"""Index utilities for RAGX."""

--- a/ragx/ragx/index/dynamic.py
+++ b/ragx/ragx/index/dynamic.py
@@ -1,0 +1,120 @@
+"""Dynamic document indexing with PII redaction and graph hooks."""
+
+from __future__ import annotations
+
+import itertools
+import math
+from collections import Counter, defaultdict
+from typing import Dict, Iterable, List
+
+from ..chunking import DocumentChunker
+from ..embeddings import EmbeddingBackend, RandomEmbeddingBackend
+from ..models import Chunk
+from .pii import redact_pii
+
+
+class InMemoryIndex:
+    """Stores chunks, embeddings and statistics for BM25 scoring."""
+
+    def __init__(self, embedding_backend: EmbeddingBackend | None = None) -> None:
+        self.embedding_backend = embedding_backend or RandomEmbeddingBackend()
+        self.chunks: Dict[str, Chunk] = {}
+        self.doc_chunks: Dict[str, List[str]] = defaultdict(list)
+        self.chunk_embeddings: List[List[float]] = []
+        self.chunk_ids: List[str] = []
+        self.term_freqs: Dict[str, Counter[str]] = {}
+        self.doc_freqs: Counter[str] = Counter()
+        self.total_chunks: int = 0
+
+    def add_chunk(self, chunk: Chunk) -> None:
+        if chunk.chunk_id in self.chunks:
+            return
+        self.chunks[chunk.chunk_id] = chunk
+        self.doc_chunks[chunk.doc_id].append(chunk.chunk_id)
+        vector = self.embedding_backend.embed_query(chunk.text)
+        self.chunk_embeddings.append(vector)
+        self.chunk_ids.append(chunk.chunk_id)
+        tokens = _tokenize(chunk.text)
+        counter = Counter(tokens)
+        self.term_freqs[chunk.chunk_id] = counter
+        for token in counter:
+            self.doc_freqs[token] += 1
+        self.total_chunks += 1
+
+    def embedding_matrix(self) -> List[List[float]]:
+        return list(self.chunk_embeddings)
+
+    def clear(self) -> None:
+        self.chunks.clear()
+        self.doc_chunks.clear()
+        self.chunk_embeddings.clear()
+        self.chunk_ids.clear()
+        self.term_freqs.clear()
+        self.doc_freqs.clear()
+        self.total_chunks = 0
+
+
+class DynamicIndexer:
+    """High-level orchestrator handling chunking, PII redaction and indexing."""
+
+    def __init__(
+        self,
+        chunker: DocumentChunker | None = None,
+        embedding_backend: EmbeddingBackend | None = None,
+        graph_adapter=None,
+    ) -> None:
+        self.chunker = chunker or DocumentChunker()
+        self.index = InMemoryIndex(embedding_backend=embedding_backend)
+        self.graph_adapter = graph_adapter
+        self._doc_counter = itertools.count()
+
+    def index_documents(self, documents: Iterable[str]) -> int:
+        count = 0
+        for text in documents:
+            doc_id = f"doc-{next(self._doc_counter)}"
+            count += self._ingest_document(doc_id, text)
+        return count
+
+    def upsert_documents(self, documents: Iterable[str]) -> int:
+        return self.index_documents(documents)
+
+    def _ingest_document(self, doc_id: str, text: str) -> int:
+        sanitized = redact_pii(text)
+        chunks = self.chunker.chunk(doc_id, sanitized)
+        for chunk in chunks:
+            self.index.add_chunk(chunk)
+            if self.graph_adapter:
+                self.graph_adapter.index_chunk(chunk)
+        return len(chunks)
+
+    def bm25_scores(self, query_tokens: List[str]) -> Dict[str, float]:
+        scores: Dict[str, float] = {}
+        if not query_tokens:
+            return scores
+        total_chunks = max(1, self.index.total_chunks)
+        avg_doc_len = sum(sum(counter.values()) for counter in self.index.term_freqs.values())
+        avg_doc_len = avg_doc_len / total_chunks if total_chunks else 0
+        k1 = 1.5
+        b = 0.75
+        for chunk_id, counter in self.index.term_freqs.items():
+            doc_len = sum(counter.values())
+            score = 0.0
+            for token in query_tokens:
+                if token not in counter:
+                    continue
+                df = self.index.doc_freqs.get(token, 1)
+                numerator = max((total_chunks - df + 0.5) / (df + 0.5), 1e-6)
+                idf = math.log(numerator)
+                tf = counter[token]
+                denom = tf + k1 * (1 - b + b * doc_len / (avg_doc_len or 1))
+                score += idf * ((tf * (k1 + 1)) / denom)
+            if score > 0:
+                scores[chunk_id] = float(score)
+        return scores
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token.lower() for token in text.split() if token]
+
+
+__all__ = ["DynamicIndexer", "InMemoryIndex", "_tokenize"]

--- a/ragx/ragx/index/pii.py
+++ b/ragx/ragx/index/pii.py
@@ -1,0 +1,21 @@
+"""Basic PII redaction for indexing."""
+
+from __future__ import annotations
+
+import re
+
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_PATTERN = re.compile(r"\b(?:\+?\d{1,3}[\s-]?)?(?:\(?\d{2,3}\)?[\s-]?)?\d{3,4}[\s-]?\d{3,4}\b")
+DATE_PATTERN = re.compile(r"\b\d{1,2}[./-]\d{1,2}[./-]\d{2,4}\b")
+
+
+def redact_pii(text: str) -> str:
+    """Mask common PII patterns before indexing."""
+
+    text = EMAIL_PATTERN.sub("<EMAIL>", text)
+    text = PHONE_PATTERN.sub("<PHONE>", text)
+    text = DATE_PATTERN.sub("<DATE>", text)
+    return text
+
+
+__all__ = ["redact_pii"]

--- a/ragx/ragx/mcp/__init__.py
+++ b/ragx/ragx/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP registry for RAGX."""

--- a/ragx/ragx/mcp/registry.py
+++ b/ragx/ragx/mcp/registry.py
@@ -1,0 +1,22 @@
+"""Minimal MCP registry managing allowed tool servers."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class MCPRegistry:
+    def __init__(self) -> None:
+        self.allowed_servers: Dict[str, Dict[str, str]] = {}
+
+    def register(self, name: str, config: Dict[str, str]) -> None:
+        self.allowed_servers[name] = config
+
+    def unregister(self, name: str) -> None:
+        self.allowed_servers.pop(name, None)
+
+    def list_servers(self) -> List[str]:
+        return list(self.allowed_servers.keys())
+
+
+__all__ = ["MCPRegistry"]

--- a/ragx/ragx/models.py
+++ b/ragx/ragx/models.py
@@ -1,0 +1,52 @@
+"""Data models for RAGX implemented with Pydantic BaseModel."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - exercised indirectly in tests
+    from pydantic import BaseModel, Field
+except ModuleNotFoundError:  # pragma: no cover - fallback when dependency unavailable
+    from ._compat import BaseModel, Field
+
+
+class Chunk(BaseModel):
+    chunk_id: str
+    doc_id: str
+    text: str
+    metadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class RetrievedChunk(Chunk):
+    retrieval_score: float = 0.0
+    rerank_score: Optional[float] = None
+    via: Optional[str] = None
+
+
+class ContextBundle(BaseModel):
+    bundle_id: str
+    task: str
+    constraints: List[str] = Field(default_factory=list)
+    decisions: List[Dict[str, Any]] = Field(default_factory=list)
+    glossary: Dict[str, str] = Field(default_factory=dict)
+    provenance: List[Dict[str, Any]] = Field(default_factory=list)
+    ttl: Optional[str] = "7d"
+    version: int = 1
+
+
+class QueryResult(BaseModel):
+    query: str
+    needs_retrieval: bool
+    query_type: str
+    retrieved: List[RetrievedChunk] = Field(default_factory=list)
+    context: str = ""
+    response: str = ""
+    meta: Dict[str, str] = Field(default_factory=dict)
+
+
+__all__ = [
+    "Chunk",
+    "RetrievedChunk",
+    "ContextBundle",
+    "QueryResult",
+]

--- a/ragx/ragx/packing.py
+++ b/ragx/ragx/packing.py
@@ -1,0 +1,43 @@
+"""Context repacking strategies."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .models import RetrievedChunk
+
+
+class Repacker:
+    def pack(self, chunks: Iterable[RetrievedChunk], mode: str = "reverse") -> str:
+        chunk_list = list(chunks)
+        if not chunk_list:
+            return ""
+        if mode == "reverse":
+            ordered = sorted(chunk_list, key=lambda c: c.retrieval_score, reverse=True)
+        elif mode == "forward":
+            ordered = sorted(chunk_list, key=lambda c: c.retrieval_score)
+        elif mode == "sides":
+            ordered = self._sides_order(chunk_list)
+        else:
+            ordered = chunk_list
+        return "\n\n".join(chunk.text for chunk in ordered)
+
+    @staticmethod
+    def _sides_order(chunks: List[RetrievedChunk]) -> List[RetrievedChunk]:
+        sorted_chunks = sorted(chunks, key=lambda c: c.retrieval_score, reverse=True)
+        ordered: List[RetrievedChunk] = []
+        left = 0
+        right = len(sorted_chunks) - 1
+        toggle = True
+        while left <= right:
+            if toggle:
+                ordered.append(sorted_chunks[left])
+                left += 1
+            else:
+                ordered.append(sorted_chunks[right])
+                right -= 1
+            toggle = not toggle
+        return ordered
+
+
+__all__ = ["Repacker"]

--- a/ragx/ragx/rerank/__init__.py
+++ b/ragx/ragx/rerank/__init__.py
@@ -1,0 +1,1 @@
+"""Reranking modules for RAGX."""

--- a/ragx/ragx/rerank/monot5.py
+++ b/ragx/ragx/rerank/monot5.py
@@ -1,0 +1,24 @@
+"""Stub monoT5 reranker with deterministic scoring."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from ..index.dynamic import _tokenize
+from ..models import RetrievedChunk
+
+
+class MonoT5Reranker:
+    def rerank(self, chunks: Iterable[RetrievedChunk], query: str, top_k: int = 5) -> List[RetrievedChunk]:
+        query_tokens = set(_tokenize(query))
+        scored = []
+        for chunk in chunks:
+            chunk_tokens = set(_tokenize(chunk.text))
+            overlap = len(query_tokens & chunk_tokens)
+            score = overlap / max(1, len(query_tokens))
+            scored.append(chunk.model_copy(update={"rerank_score": float(score)}))
+        scored.sort(key=lambda c: (c.rerank_score or 0.0, c.retrieval_score), reverse=True)
+        return scored[:top_k]
+
+
+__all__ = ["MonoT5Reranker"]

--- a/ragx/ragx/rerank/tildev2.py
+++ b/ragx/ragx/rerank/tildev2.py
@@ -1,0 +1,24 @@
+"""Stub TILDEv2 reranker focusing on term coverage."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from ..index.dynamic import _tokenize
+from ..models import RetrievedChunk
+
+
+class TILDEV2Reranker:
+    def rerank(self, chunks: Iterable[RetrievedChunk], query: str, top_k: int = 5) -> List[RetrievedChunk]:
+        query_tokens = _tokenize(query)
+        scored = []
+        for chunk in chunks:
+            chunk_tokens = _tokenize(chunk.text)
+            coverage = sum(chunk_tokens.count(token) for token in query_tokens)
+            score = coverage / max(1, len(chunk_tokens))
+            scored.append(chunk.model_copy(update={"rerank_score": float(score)}))
+        scored.sort(key=lambda c: (c.rerank_score or 0.0, c.retrieval_score), reverse=True)
+        return scored[:top_k]
+
+
+__all__ = ["TILDEV2Reranker"]

--- a/ragx/ragx/retrievers/__init__.py
+++ b/ragx/ragx/retrievers/__init__.py
@@ -1,0 +1,1 @@
+"""Retrieval components for RAGX."""

--- a/ragx/ragx/retrievers/graphrag_adapter.py
+++ b/ragx/ragx/retrievers/graphrag_adapter.py
@@ -1,0 +1,66 @@
+"""Minimal GraphRAG adapter using simple adjacency maps."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Dict, List, Set
+
+from ..models import Chunk, RetrievedChunk
+
+
+def _extract_terms(text: str) -> List[str]:
+    words = [word.strip(".,;:()[]{}<>!?\"") for word in text.split()]
+    return [word.lower() for word in words if len(word) > 4]
+
+
+class GraphRAGAdapter:
+    """Constructs a lightweight knowledge graph of chunk terms."""
+
+    def __init__(self) -> None:
+        self.chunk_terms: Dict[str, List[str]] = {}
+        self.term_to_chunks: Dict[str, Set[str]] = defaultdict(set)
+
+    def index_chunk(self, chunk: Chunk) -> None:
+        terms = _extract_terms(chunk.text)
+        self.chunk_terms[chunk.chunk_id] = terms
+        for term in terms:
+            self.term_to_chunks[term].add(chunk.chunk_id)
+
+    def remove_chunk(self, chunk_id: str) -> None:
+        terms = self.chunk_terms.pop(chunk_id, [])
+        for term in terms:
+            bucket = self.term_to_chunks.get(term)
+            if not bucket:
+                continue
+            bucket.discard(chunk_id)
+            if not bucket:
+                self.term_to_chunks.pop(term, None)
+
+    def retrieve_via_graph(
+        self,
+        query: str,
+        chunk_lookup: Dict[str, Chunk],
+        top_k: int = 3,
+    ) -> List[RetrievedChunk]:
+        terms = _extract_terms(query)
+        if not terms:
+            return []
+        scores = Counter()
+        for term in terms:
+            for chunk_id in self.term_to_chunks.get(term, []):
+                scores[chunk_id] += 1.0
+        ranked = scores.most_common(top_k)
+        results = []
+        for chunk_id, score in ranked:
+            chunk = chunk_lookup[chunk_id]
+            results.append(
+                RetrievedChunk(
+                    **chunk.model_dump(),
+                    retrieval_score=float(score),
+                    via="graphrag",
+                )
+            )
+        return results
+
+
+__all__ = ["GraphRAGAdapter"]

--- a/ragx/ragx/retrievers/hybrid.py
+++ b/ragx/ragx/retrievers/hybrid.py
@@ -1,0 +1,74 @@
+"""Hybrid retriever combining lexical and dense scores."""
+
+from __future__ import annotations
+
+from typing import List
+
+from ..embeddings import cosine_similarity
+from ..models import RetrievedChunk
+from ..index.dynamic import DynamicIndexer, _tokenize
+
+
+class HybridRetriever:
+    def __init__(self, indexer: DynamicIndexer, alpha: float = 0.3) -> None:
+        self.indexer = indexer
+        self.alpha = alpha
+
+    def set_alpha(self, value: float) -> None:
+        self.alpha = float(min(max(value, 0.0), 1.0))
+
+    def retrieve(self, query: str, top_k: int | None = None) -> List[RetrievedChunk]:
+        top_k = top_k or 10
+        query_tokens = _tokenize(query)
+        bm25_scores = self.indexer.bm25_scores(query_tokens)
+        matrix = self.indexer.index.embedding_matrix()
+        if matrix:
+            query_vec = self.indexer.index.embedding_backend.embed_query(query)
+            dense_scores = cosine_similarity(query_vec, matrix)
+        else:
+            dense_scores = [0.0 for _ in self.indexer.index.chunk_ids]
+
+        dense_scores = _normalize_dense(dense_scores)
+        bm25_array = _scores_to_array(bm25_scores, self.indexer.index.chunk_ids)
+        bm25_array = _normalize_array(bm25_array)
+
+        combined = [
+            self.alpha * dense + (1 - self.alpha) * bm25
+            for dense, bm25 in zip(dense_scores, bm25_array)
+        ]
+        ranked_indices = sorted(range(len(combined)), key=lambda i: combined[i], reverse=True)[:top_k]
+        results: List[RetrievedChunk] = []
+        for idx in ranked_indices:
+            chunk_id = self.indexer.index.chunk_ids[idx]
+            chunk = self.indexer.index.chunks[chunk_id]
+            results.append(
+                RetrievedChunk(
+                    **chunk.model_dump(),
+                    retrieval_score=float(combined[idx]),
+                    rerank_score=None,
+                    via="hybrid",
+                )
+            )
+        return results
+
+
+def _scores_to_array(scores: dict[str, float], ordered_ids: List[str]) -> List[float]:
+    return [scores.get(chunk_id, 0.0) for chunk_id in ordered_ids]
+
+
+def _normalize_array(values: List[float]) -> List[float]:
+    if not values:
+        return values
+    max_value = max(values)
+    if max_value <= 0:
+        return [0.0 for _ in values]
+    return [value / max_value for value in values]
+
+
+def _normalize_dense(values: List[float]) -> List[float]:
+    if not values:
+        return values
+    return [(value + 1.0) / 2.0 for value in values]
+
+
+__all__ = ["HybridRetriever"]

--- a/ragx/ragx/retrievers/tensor_iface.py
+++ b/ragx/ragx/retrievers/tensor_iface.py
@@ -1,0 +1,22 @@
+"""Tensor retriever placeholder to hook ColBERT/ColPali implementations."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from ..models import Chunk, RetrievedChunk
+
+
+class TensorRetrieverInterface:
+    def __init__(self) -> None:
+        self.indexed_chunks: List[Chunk] = []
+
+    def index(self, chunks: Iterable[Chunk]) -> None:
+        self.indexed_chunks.extend(chunks)
+
+    def search(self, query: str, top_k: int = 5) -> List[RetrievedChunk]:
+        # Placeholder: return empty list. Backend can override.
+        return []
+
+
+__all__ = ["TensorRetrieverInterface"]

--- a/ragx/ragx/summarize/__init__.py
+++ b/ragx/ragx/summarize/__init__.py
@@ -1,0 +1,1 @@
+"""Summarization utilities for RAGX."""

--- a/ragx/ragx/summarize/longllmlingua.py
+++ b/ragx/ragx/summarize/longllmlingua.py
@@ -1,0 +1,17 @@
+"""Fallback summarizer approximating LongLLMLingua."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..models import RetrievedChunk
+
+
+class LongLLMLinguaSummarizer:
+    def summarize(self, chunks: Iterable[RetrievedChunk], target_tokens: int = 300) -> str:
+        text = " ".join(chunk.text for chunk in chunks)
+        words = text.split()
+        return " ".join(words[:target_tokens])
+
+
+__all__ = ["LongLLMLinguaSummarizer"]

--- a/ragx/ragx/summarize/recomp.py
+++ b/ragx/ragx/summarize/recomp.py
@@ -1,0 +1,31 @@
+"""Abstractive summarizer stub representing RECOMP."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..models import RetrievedChunk
+
+
+class RecompSummarizer:
+    def summarize(self, chunks: Iterable[RetrievedChunk], target_tokens: int = 400) -> str:
+        sentences = []
+        for chunk in chunks:
+            for sentence in chunk.text.split(". "):
+                sentence = sentence.strip()
+                if sentence and sentence not in sentences:
+                    sentences.append(sentence)
+        summary = []
+        word_budget = target_tokens
+        for sentence in sentences:
+            words = sentence.split()
+            if len(words) > word_budget:
+                break
+            summary.append(sentence)
+            word_budget -= len(words)
+            if word_budget <= 0:
+                break
+        return ". ".join(summary)
+
+
+__all__ = ["RecompSummarizer"]

--- a/ragx/tests/test_agentic.py
+++ b/ragx/tests/test_agentic.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ragx.api import public_api
+from ragx.control.planner import Planner
+from ragx.models import QueryResult
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    public_api._reset_state_for_tests()
+    yield
+    public_api._reset_state_for_tests()
+
+
+def test_planner_includes_graph_step():
+    planner = Planner()
+    plan = planner.plan("Compare solar and wind adoption globally")
+    assert any(step.name == "graph_retrieve" for step in plan)
+
+
+def test_agentic_pipeline_triggers_critic_retry():
+    result = public_api.answer_agentic("Compare fusion and fission energy outputs")
+    assert isinstance(result, QueryResult)
+    assert result.meta.get("critic_retries") == "1"
+    assert result.meta.get("critic_status") == "LOW_CONFIDENCE"

--- a/ragx/tests/test_budget.py
+++ b/ragx/tests/test_budget.py
@@ -1,0 +1,14 @@
+from ragx.control.budget import ContextBudgeter
+from ragx.models import RetrievedChunk
+from ragx.summarize.longllmlingua import LongLLMLinguaSummarizer
+from ragx.summarize.recomp import RecompSummarizer
+
+
+def test_budget_enforces_limit():
+    chunk_text = "Energy efficiency improvements reduce overall demand and lower emissions significantly. " * 10
+    chunk = RetrievedChunk(chunk_id="c1", doc_id="d1", text=chunk_text, retrieval_score=0.9)
+    context = " ".join(chunk_text.split() * 2)
+    budgeter = ContextBudgeter(50, RecompSummarizer(), LongLLMLinguaSummarizer())
+    result = budgeter.enforce(context, [chunk])
+    assert len(result.context.split()) <= 50
+    assert result.strategy in {"primary", "fallback"}

--- a/ragx/tests/test_crag_selfrag.py
+++ b/ragx/tests/test_crag_selfrag.py
@@ -1,0 +1,31 @@
+from ragx.control.crag import CRAGEvaluator
+from ragx.control.selfrag import SelfRAGRewriter
+from ragx.models import RetrievedChunk
+
+
+def test_crag_triggers_retry():
+    chunks = [
+        RetrievedChunk(chunk_id="c1", doc_id="d1", text="Sparse info", retrieval_score=0.05),
+        RetrievedChunk(chunk_id="c2", doc_id="d2", text="More sparse info", retrieval_score=0.07),
+    ]
+    evaluator = CRAGEvaluator(min_score=0.55)
+    result = evaluator.evaluate(chunks)
+    assert result.action == "retry"
+    assert result.score < 0.55
+
+
+def test_selfrag_rewrite_loop():
+    chunks = [
+        RetrievedChunk(
+            chunk_id="c1",
+            doc_id="d1",
+            text="Photosynthesis efficiency depends on chlorophyll concentration and photon flux.",
+            retrieval_score=0.9,
+        )
+    ]
+    rewriter = SelfRAGRewriter(max_loops=2)
+    original_query = "plant growth"
+    result = rewriter.rewrite_loop(original_query, chunks)
+    assert result.final_query != original_query
+    assert len(result.rewrites) <= 2
+    assert "chlorophyll" in result.final_query

--- a/ragx/tests/test_retrieval.py
+++ b/ragx/tests/test_retrieval.py
@@ -1,0 +1,50 @@
+import pytest
+
+from ragx.api import public_api
+
+
+DOCS = [
+    "Climate change increases global temperatures and drives extreme weather patterns.",
+    "Renewable energy adoption grows as solar and wind become cheaper than coal.",
+    "Economic recovery depends on sustainable policies supporting green infrastructure.",
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    public_api._reset_state_for_tests()
+    yield
+    public_api._reset_state_for_tests()
+
+
+@pytest.fixture
+def indexed_corpus():
+    public_api.index_documents(DOCS)
+    return DOCS
+
+
+def test_hybrid_alpha_stability(indexed_corpus):
+    query = "climate change energy"
+    first_chunks = []
+    for alpha in [0.1, 0.3, 0.5]:
+        public_api.set_alpha(alpha)
+        retrieved = public_api._state.retriever.retrieve(query, top_k=3)
+        assert retrieved, "Expected non-empty retrieval results"
+        first_chunks.append(retrieved[0].chunk_id)
+    assert len(set(first_chunks)) == 1
+
+
+def test_dense_bm25_deterministic(indexed_corpus):
+    query = "renewable energy adoption"
+    public_api.set_alpha(0.3)
+    first_call = public_api._state.retriever.retrieve(query, top_k=2)
+    second_call = public_api._state.retriever.retrieve(query, top_k=2)
+    assert [chunk.chunk_id for chunk in first_call] == [chunk.chunk_id for chunk in second_call]
+
+
+def test_combined_scores_range(indexed_corpus):
+    query = "green infrastructure"
+    public_api.set_alpha(0.5)
+    retrieved = public_api._state.retriever.retrieve(query, top_k=3)
+    for chunk in retrieved:
+        assert 0.0 <= chunk.retrieval_score <= 1.0


### PR DESCRIPTION
## Summary
- update the RAGX models to derive from pydantic BaseModel while keeping field defaults intact
- add a lightweight compatibility shim so environments without the pydantic dependency still expose the expected BaseModel and Field APIs

## Testing
- PYTHONPATH=ragx pytest ragx/tests

------
https://chatgpt.com/codex/tasks/task_e_68cc09d7b4fc833282405b30ea40dc36